### PR TITLE
replaces use of deprecated transferPropsTo with object-assign shim

### DIFF
--- a/ReactMarkdown.js
+++ b/ReactMarkdown.js
@@ -1,6 +1,7 @@
 
 var React = require('react'),
-    markdown = require('markdown');
+    markdown = require('markdown'),
+    objectAssign = require('object-assign');
 
 var Markdown = React.createClass({
 
@@ -17,10 +18,11 @@ var Markdown = React.createClass({
 
     render: function() {
         var El = React.DOM[this.props.el];
-        return this.transferPropsTo(El({
+        var props = objectAssign({}, this.props, {
             className: 'markdown',
             dangerouslySetInnerHTML: { __html: markdown.parse(this.props.text) }
-        }));
+        });
+        return El(props);
     }
 
 });

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "dependencies": {
-    "markdown": "^0.5.0"
+    "markdown": "^0.5.0",
+    "object-assign": "^2.0.0"
   },
   "peerDependencies": {
     "react": "*"


### PR DESCRIPTION
Method transferPropsTo deprecated 0.12 and removed in 0.13.
