### PR TITLE
markdown-js require string in markdown.parse

### DIFF
--- a/ReactMarkdown.js
+++ b/ReactMarkdown.js
@@ -12,7 +12,8 @@ var Markdown = React.createClass({
 
     getDefaultProps: function() {
         return {
-            el: 'div'
+            el: 'div',
+            text: ''
         };
     },
 


### PR DESCRIPTION
`markdown.parse` require string as first argument

this component mark `text` property as option

should provide default value
